### PR TITLE
[composer.json] Dependency updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "php": ">=5.3.3",
         "psr/log": "^1.0",
-        "justinrainbow/json-schema": "~1.4",
-        "twig/twig": "1.18.*"
+        "justinrainbow/json-schema": "^1.4",
+        "twig/twig": "^1.18"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.8.1",


### PR DESCRIPTION
- `twig/twig`: Allow any 1.x version >= 1.18
- `justinrainbow/json-schema`: Use `^` instead of `~` (no difference in this case, just consistency with other dependencies)
