### PR TITLE
Initial Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+    - '5.3'
+    - '5.4'
+    - '5.5'
+    - '5.6'
+    - '7.0'
+    - hhvm
+    - nightly
+
+before_script:
+    - composer self-update
+    - composer install --prefer-source --no-interaction
+
+script: composer test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Packagist](https://img.shields.io/packagist/v/pattern-builder/pattern-builder.svg?maxAge=2592000)]()
 [![Packagist](https://img.shields.io/packagist/l/pattern-builder/pattern-builder.svg?maxAge=2592000)]()
+[![Travis](https://img.shields.io/travis/PatternBuilder/pattern-builder-lib-php.svg?maxAge=2592000)](https://travis-ci.org/PatternBuilder/pattern-builder-lib-php)
 
 # Pattern Builder PHP Library
 


### PR DESCRIPTION
NOTE: I would like to enable tests for PHP 5.3.3 specifically (because RHEL 6) but the openssl extension is not compiled with 5.3.3 on Travis.  There are several ways to get around this issue, but we can worry about those later.  This will take care of the latest 5.3, 5.4, 5.5, 5.6, 7.0, nightly, and HHVM.
